### PR TITLE
Fix PK attribute labels not underlined in Chen notation

### DIFF
--- a/src/renderer/chen/__tests__/ChenAttributeNode.test.tsx
+++ b/src/renderer/chen/__tests__/ChenAttributeNode.test.tsx
@@ -140,6 +140,30 @@ describe('ChenAttributeNode', () => {
     expect(node.className).toContain('bg-blue-100');
   });
 
+  it('underlines primary key attribute label', () => {
+    const attr = makeAttr({ name: 'id' });
+    render(
+      <ReactFlowProvider>
+        <ChenAttributeNode {...makeNodeProps(attr, { isPrimaryKey: true })} />
+      </ReactFlowProvider>,
+    );
+
+    const label = screen.getByText('id');
+    expect(label.className).toContain('underline');
+  });
+
+  it('does not underline non-primary-key attribute label', () => {
+    const attr = makeAttr({ name: 'email' });
+    render(
+      <ReactFlowProvider>
+        <ChenAttributeNode {...makeNodeProps(attr)} />
+      </ReactFlowProvider>,
+    );
+
+    const label = screen.getByText('email');
+    expect(label.className).not.toContain('underline');
+  });
+
   it('has a circle element with rounded-full class', () => {
     render(
       <ReactFlowProvider>

--- a/src/renderer/chen/nodes/ChenAttributeNode.tsx
+++ b/src/renderer/chen/nodes/ChenAttributeNode.tsx
@@ -37,7 +37,7 @@ export function ChenAttributeNode({ data, selected }: NodeProps<ChenAttributeNod
       />
 
       {/* Name label outside the circle */}
-      <span className="text-xs text-gray-800 whitespace-nowrap">
+      <span className={`text-xs text-gray-800 whitespace-nowrap ${isPrimaryKey ? 'underline' : ''}`}>
         {attribute.name}
       </span>
     </div>


### PR DESCRIPTION
## Summary
- Add conditional `underline` class to primary key attribute labels in `ChenAttributeNode` so they follow standard ERD conventions
- Add tests verifying PK labels are underlined and non-PK labels are not

Closes #1

## Test plan
- [x] All 592 existing tests pass
- [ ] Verify in browser: Chen notation PK attribute labels are underlined
- [ ] Verify non-PK attributes remain without underline