### PR TITLE
Fix Crow's Foot notation visual bugs

### DIFF
--- a/src/renderer/chen/ChenRenderer.ts
+++ b/src/renderer/chen/ChenRenderer.ts
@@ -7,6 +7,7 @@ import type { ChenRelationshipNodeData } from './nodes/ChenRelationshipNode';
 import type { ChenAggregationNodeData } from './nodes/ChenAggregationNode';
 import type { ChenJunctionNodeData } from './nodes/ChenJunctionNode';
 import type { ChenEdgeData } from './edges/ChenEdge';
+import { getHandlesForPair } from '../shared/getHandlesForPair';
 
 const ATTR_RADIUS = 120;
 const ATTR_START_ANGLE = -Math.PI / 2;
@@ -24,35 +25,6 @@ function computeAttributePosition(
     x: parentPos.x + ATTR_RADIUS * Math.cos(angle),
     y: parentPos.y + ATTR_RADIUS * Math.sin(angle),
   };
-}
-
-/**
- * Determine which side of the parent the attribute is on,
- * returning the appropriate source handle (on the entity) and target handle (on the attribute).
- */
-function getHandlesForAttr(
-  parentPos: { x: number; y: number },
-  attrPos: { x: number; y: number },
-): { sourceHandle: string; targetHandle: string } {
-  const dx = attrPos.x - parentPos.x;
-  const dy = attrPos.y - parentPos.y;
-
-  // Determine dominant direction
-  if (Math.abs(dx) > Math.abs(dy)) {
-    // Horizontal: attribute is to the left or right
-    if (dx > 0) {
-      return { sourceHandle: 'right-src', targetHandle: 'left' };
-    } else {
-      return { sourceHandle: 'left-src', targetHandle: 'right' };
-    }
-  } else {
-    // Vertical: attribute is above or below
-    if (dy > 0) {
-      return { sourceHandle: 'bottom-src', targetHandle: 'top' };
-    } else {
-      return { sourceHandle: 'top-src', targetHandle: 'bottom' };
-    }
-  }
 }
 
 // Approximate node dimensions for handle position calculation
@@ -155,7 +127,7 @@ export const chenRenderer: Renderer = {
         });
 
         // Compute junction on the actual handle-to-handle line
-        const erHandlesForJunction = getHandlesForAttr(dominantEntity.position, identRel.position);
+        const erHandlesForJunction = getHandlesForPair(dominantEntity.position, identRel.position);
         const relExit = getHandleExitPoint(
           identRel.position,
           handleSide(erHandlesForJunction.targetHandle),
@@ -216,7 +188,7 @@ export const chenRenderer: Renderer = {
         };
         nodes.push(attrNode);
 
-        const handles = getHandlesForAttr(entity.position, attrPosition);
+        const handles = getHandlesForPair(entity.position, attrPosition);
         const attrEdge: Edge<ChenEdgeData> = {
           id: `edge::ea::${entity.id}::${attr.id}`,
           source: `entity::${entity.id}`,
@@ -256,7 +228,7 @@ export const chenRenderer: Renderer = {
         nodes.push(attrNode);
 
         // Edge 1: entity → partial key attribute (normal attribute connection)
-        const entityHandles = getHandlesForAttr(entity.position, attrPosition);
+        const entityHandles = getHandlesForPair(entity.position, attrPosition);
         edges.push({
           id: `edge::ea::${entity.id}::${attr.id}`,
           source: `entity::${entity.id}`,
@@ -270,14 +242,14 @@ export const chenRenderer: Renderer = {
         // Edge 2: partial key attribute → junction node (branches to the participation line)
         if (wInfo) {
           // Use same handle-to-handle calculation for the junction position
-          const pkHandles = getHandlesForAttr(wInfo.dominantPos, wInfo.relPos);
+          const pkHandles = getHandlesForPair(wInfo.dominantPos, wInfo.relPos);
           const pkRelExit = getHandleExitPoint(wInfo.relPos, handleSide(pkHandles.targetHandle), 'relationship');
           const pkDomExit = getHandleExitPoint(wInfo.dominantPos, handleSide(pkHandles.sourceHandle), 'entity');
           const junctionPos = {
             x: (pkRelExit.x + pkDomExit.x) / 2,
             y: (pkRelExit.y + pkDomExit.y) / 2,
           };
-          const junctionHandles = getHandlesForAttr(attrPosition, junctionPos);
+          const junctionHandles = getHandlesForPair(attrPosition, junctionPos);
           edges.push({
             id: `edge::pk::${entity.id}::${attr.id}`,
             source: attrNodeId,
@@ -319,7 +291,7 @@ export const chenRenderer: Renderer = {
         }
 
         // Straight edge from entity to relationship (junction dot sits on top visually)
-        const erHandles = getHandlesForAttr(participantPos, rel.position);
+        const erHandles = getHandlesForPair(participantPos, rel.position);
 
         const erEdge: Edge<ChenEdgeData> = {
           id: `edge::er::${rel.id}::${participant.entityId}${participant.role ? `::${participant.role}` : ''}`,
@@ -356,7 +328,7 @@ export const chenRenderer: Renderer = {
         };
         nodes.push(attrNode);
 
-        const relAttrHandles = getHandlesForAttr(rel.position, relAttrPosition);
+        const relAttrHandles = getHandlesForPair(rel.position, relAttrPosition);
         const raEdge: Edge<ChenEdgeData> = {
           id: `edge::ra::${rel.id}::${attr.id}`,
           source: `rel::${rel.id}`,

--- a/src/renderer/crowsfoot/CrowsFootRenderer.ts
+++ b/src/renderer/crowsfoot/CrowsFootRenderer.ts
@@ -4,6 +4,7 @@ import type { ERDModel, Entity } from '../../ir/types';
 import type { CrowsFootEntityNodeData, ForeignKeyInfo } from './nodes/CrowsFootEntityNode';
 import type { CrowsFootEdgeData } from './edges/CrowsFootEdge';
 import { isMany, fkColumnName } from '../../utils/cardinality';
+import { getHandlesForPair } from '../shared/getHandlesForPair';
 
 function computeForeignKeys(entity: Entity, model: ERDModel): ForeignKeyInfo[] {
   const fks: ForeignKeyInfo[] = [];
@@ -75,6 +76,9 @@ export const crowsFootRenderer: Renderer = {
     const nodes: Node[] = [];
     const edges: Edge[] = [];
 
+    // Build position lookup for handle assignment
+    const positionMap = new Map<string, { x: number; y: number }>();
+
     // Process entities
     for (const entity of model.entities) {
       const foreignKeys = computeForeignKeys(entity, model);
@@ -86,6 +90,7 @@ export const crowsFootRenderer: Renderer = {
         data: { entity, foreignKeys },
       };
       nodes.push(entityNode);
+      positionMap.set(entity.id, entity.position);
     }
 
     // Process aggregations as virtual entity nodes
@@ -107,6 +112,8 @@ export const crowsFootRenderer: Renderer = {
         ? participantPositions.reduce((s, p) => s + p.y, 0) / participantPositions.length + 150
         : 300;
 
+      const aggPosition = { x: avgX, y: avgY };
+
       // Create a virtual entity representing the aggregation
       const virtualEntity: Entity = {
         id: agg.id,
@@ -114,16 +121,17 @@ export const crowsFootRenderer: Renderer = {
         isWeak: false,
         attributes: [],
         candidateKeys: [],
-        position: { x: avgX, y: avgY },
+        position: aggPosition,
       };
 
       const aggNode: Node<CrowsFootEntityNodeData> = {
         id: `entity::${agg.id}`,
         type: 'crowsfootEntity',
-        position: virtualEntity.position,
+        position: aggPosition,
         data: { entity: virtualEntity, foreignKeys: [] },
       };
       nodes.push(aggNode);
+      positionMap.set(agg.id, aggPosition);
     }
 
     // Process relationships as edges between entities
@@ -136,10 +144,16 @@ export const crowsFootRenderer: Renderer = {
       const sourceNodeId = `entity::${source.entityId}`;
       const targetNodeId = `entity::${target.entityId}`;
 
+      const sourcePos = positionMap.get(source.entityId) ?? { x: 0, y: 0 };
+      const targetPos = positionMap.get(target.entityId) ?? { x: 0, y: 0 };
+      const handles = getHandlesForPair(sourcePos, targetPos);
+
       const edge: Edge<CrowsFootEdgeData> = {
         id: `edge::${rel.id}`,
         source: sourceNodeId,
         target: targetNodeId,
+        sourceHandle: handles.sourceHandle,
+        targetHandle: handles.targetHandle,
         type: 'crowsfootEdge',
         data: {
           relationship: rel,

--- a/src/renderer/crowsfoot/__tests__/CrowsFootEdge.test.tsx
+++ b/src/renderer/crowsfoot/__tests__/CrowsFootEdge.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { ReactFlowProvider, ReactFlow } from '@xyflow/react';
-import { CrowsFootEdge, drawMarker } from '../edges/CrowsFootEdge';
+import { ReactFlowProvider, ReactFlow, Position } from '@xyflow/react';
+import { CrowsFootEdge, drawMarker, positionToAngle } from '../edges/CrowsFootEdge';
 import type { Relationship, Cardinality } from '../../../ir/types';
 
 // ReactFlow requires ResizeObserver which is not available in jsdom
@@ -303,5 +303,64 @@ describe('drawMarker', () => {
     const keys = elements.map((e) => e.key);
     expect(keys).toContain('circle');
     expect(keys).toContain('one');
+  });
+});
+
+describe('positionToAngle', () => {
+  it('returns 0 for Position.Right (outward/rightward)', () => {
+    expect(positionToAngle(Position.Right)).toBe(0);
+  });
+
+  it('returns PI for Position.Left (outward/leftward)', () => {
+    expect(positionToAngle(Position.Left)).toBe(Math.PI);
+  });
+
+  it('returns PI/2 for Position.Bottom (outward/downward)', () => {
+    expect(positionToAngle(Position.Bottom)).toBe(Math.PI / 2);
+  });
+
+  it('returns -PI/2 for Position.Top (outward/upward)', () => {
+    expect(positionToAngle(Position.Top)).toBe(-Math.PI / 2);
+  });
+});
+
+describe('drawMarker axis-aligned output', () => {
+  it('crow foot prongs spread at entity, converging outward (angle 0, Position.Right)', () => {
+    const elements = drawMarker({ min: 1, max: '*' }, 100, 100, 0);
+    const crow1 = elements.find((e) => e.key === 'crow1');
+    const crow2 = elements.find((e) => e.key === 'crow2');
+    const crow3 = elements.find((e) => e.key === 'crow3');
+    expect(crow1).toBeDefined();
+    expect(crow2).toBeDefined();
+    expect(crow3).toBeDefined();
+    // Middle prong starts at (100,100), converges to (110,100)
+    expect(crow2!.props.x1).toBe(100);
+    expect(crow2!.props.y1).toBe(100);
+    expect(crow2!.props.x2).toBe(110);
+    expect(crow2!.props.y2).toBe(100);
+    // All three prongs converge to the same outward point
+    expect(crow1!.props.x2).toBe(crow2!.props.x2);
+    expect(crow1!.props.y2).toBe(crow2!.props.y2);
+    expect(crow3!.props.x2).toBe(crow2!.props.x2);
+    expect(crow3!.props.y2).toBe(crow2!.props.y2);
+    // Top and bottom prongs are spread perpendicular at the entity end
+    expect(crow1!.props.y1).toBeLessThan(crow2!.props.y1);
+    expect(crow3!.props.y1).toBeGreaterThan(crow2!.props.y1);
+  });
+
+  it('crow foot prongs spread at entity, converging outward (angle PI/2, Position.Bottom)', () => {
+    const elements = drawMarker({ min: 1, max: '*' }, 100, 100, Math.PI / 2);
+    const crow2 = elements.find((e) => e.key === 'crow2');
+    expect(crow2).toBeDefined();
+    // Middle prong: (100,100) → (100,110) — x1 === x2
+    expect(Math.abs(crow2!.props.x1 - crow2!.props.x2)).toBeLessThan(0.001);
+  });
+
+  it('one-line is perpendicular to horizontal edge (angle PI, Position.Left)', () => {
+    const elements = drawMarker({ min: 0, max: 1 }, 100, 100, Math.PI);
+    const oneLine = elements.find((e) => e.key === 'one');
+    expect(oneLine).toBeDefined();
+    // x1 should equal x2 (vertical bar perpendicular to horizontal direction)
+    expect(Math.abs(oneLine!.props.x1 - oneLine!.props.x2)).toBeLessThan(0.001);
   });
 });

--- a/src/renderer/crowsfoot/__tests__/CrowsFootRenderer.test.ts
+++ b/src/renderer/crowsfoot/__tests__/CrowsFootRenderer.test.ts
@@ -743,6 +743,119 @@ describe('CrowsFootRenderer', () => {
     expect(aggNode?.position).toEqual({ x: 300, y: 300 });
   });
 
+  // -----------------------------------------------------------------------
+  // Edge handle assignment based on relative entity positions
+  // -----------------------------------------------------------------------
+  it('assigns right-src/left handles for horizontally arranged entities', () => {
+    const model: ERDModel = {
+      entities: [
+        makeEntity({ id: 'e1', name: 'A', position: { x: 0, y: 0 } }),
+        makeEntity({ id: 'e2', name: 'B', position: { x: 300, y: 0 } }),
+      ],
+      relationships: [
+        makeRelationship({
+          id: 'r1',
+          name: 'Rel',
+          participants: [
+            { entityId: 'e1', cardinality: { min: 1, max: 1 } },
+            { entityId: 'e2', cardinality: { min: 0, max: '*' } },
+          ],
+        }),
+      ],
+      aggregations: [],
+    };
+
+    const { edges } = crowsFootRenderer.render(model);
+    expect(edges[0].sourceHandle).toBe('right-src');
+    expect(edges[0].targetHandle).toBe('left');
+  });
+
+  it('assigns bottom-src/top handles for vertically arranged entities', () => {
+    const model: ERDModel = {
+      entities: [
+        makeEntity({ id: 'e1', name: 'A', position: { x: 0, y: 0 } }),
+        makeEntity({ id: 'e2', name: 'B', position: { x: 0, y: 300 } }),
+      ],
+      relationships: [
+        makeRelationship({
+          id: 'r1',
+          name: 'Rel',
+          participants: [
+            { entityId: 'e1', cardinality: { min: 1, max: 1 } },
+            { entityId: 'e2', cardinality: { min: 0, max: '*' } },
+          ],
+        }),
+      ],
+      aggregations: [],
+    };
+
+    const { edges } = crowsFootRenderer.render(model);
+    expect(edges[0].sourceHandle).toBe('bottom-src');
+    expect(edges[0].targetHandle).toBe('top');
+  });
+
+  it('assigns left-src/right handles when target is to the left of source', () => {
+    const model: ERDModel = {
+      entities: [
+        makeEntity({ id: 'e1', name: 'A', position: { x: 300, y: 0 } }),
+        makeEntity({ id: 'e2', name: 'B', position: { x: 0, y: 0 } }),
+      ],
+      relationships: [
+        makeRelationship({
+          id: 'r1',
+          name: 'Rel',
+          participants: [
+            { entityId: 'e1', cardinality: { min: 1, max: 1 } },
+            { entityId: 'e2', cardinality: { min: 0, max: '*' } },
+          ],
+        }),
+      ],
+      aggregations: [],
+    };
+
+    const { edges } = crowsFootRenderer.render(model);
+    expect(edges[0].sourceHandle).toBe('left-src');
+    expect(edges[0].targetHandle).toBe('right');
+  });
+
+  it('assigns handles for aggregation virtual entity edges', () => {
+    const model: ERDModel = {
+      entities: [
+        makeEntity({ id: 'e1', name: 'Student', position: { x: 0, y: 0 } }),
+        makeEntity({ id: 'e2', name: 'Course', position: { x: 300, y: 0 } }),
+        makeEntity({ id: 'e3', name: 'Professor', position: { x: 150, y: 300 } }),
+      ],
+      relationships: [
+        makeRelationship({
+          id: 'r1',
+          name: 'Enrolls',
+          position: { x: 150, y: 0 },
+          participants: [
+            { entityId: 'e1', cardinality: { min: 0, max: '*' } },
+            { entityId: 'e2', cardinality: { min: 0, max: '*' } },
+          ],
+        }),
+        makeRelationship({
+          id: 'r2',
+          name: 'Monitors',
+          position: { x: 150, y: 200 },
+          participants: [
+            { entityId: 'agg1', cardinality: { min: 1, max: 1 }, isAggregation: true },
+            { entityId: 'e3', cardinality: { min: 0, max: '*' } },
+          ],
+        }),
+      ],
+      aggregations: [{ id: 'agg1', name: 'Enrollment', relationshipId: 'r1' }],
+    };
+
+    const { edges } = crowsFootRenderer.render(model);
+    const monitorEdge = edges.find((e) => e.id === 'edge::r2');
+    expect(monitorEdge).toBeDefined();
+    // agg1 position is (150, 150), e3 is (150, 300) → vertical, target below
+    expect(monitorEdge?.sourceHandle).toBe('bottom-src');
+    expect(monitorEdge?.targetHandle).toBe('top');
+  });
+
   it('creates edge connecting aggregation virtual entity to another entity', () => {
     const model: ERDModel = {
       entities: [

--- a/src/renderer/crowsfoot/edges/CrowsFootEdge.tsx
+++ b/src/renderer/crowsfoot/edges/CrowsFootEdge.tsx
@@ -2,6 +2,7 @@ import {
   BaseEdge,
   EdgeLabelRenderer,
   getSmoothStepPath,
+  Position,
   type EdgeProps,
   type Edge,
 } from '@xyflow/react';
@@ -30,10 +31,15 @@ export function drawMarker(
   const isMany = cardinality.max === '*' || (typeof cardinality.max === 'number' && cardinality.max > 1);
   const isOptional = cardinality.min === 0;
 
+  // Place the min-cardinality symbol (bar/circle) beyond the max symbol.
+  // For "many" the crow's foot convergence is at `size` px, so place beyond that.
+  // For "one" the perpendicular line is at 0px, so place close to it.
+  const minOffset = isMany ? size + 5 : 10;
+
   if (isOptional) {
     // Circle for optional
-    const cx = x + cos * (size + 5);
-    const cy = y + sin * (size + 5);
+    const cx = x + cos * minOffset;
+    const cy = y + sin * minOffset;
     elements.push(
       <circle
         key="circle"
@@ -47,8 +53,8 @@ export function drawMarker(
     );
   } else {
     // Bar for mandatory
-    const bx = x + cos * (size + 5);
-    const by = y + sin * (size + 5);
+    const bx = x + cos * minOffset;
+    const by = y + sin * minOffset;
     const perpX = -sin * 8;
     const perpY = cos * 8;
     elements.push(
@@ -65,30 +71,36 @@ export function drawMarker(
   }
 
   if (isMany) {
-    // Crow's foot (three lines spreading out)
+    // Crow's foot: three prongs at entity (x,y) converging to a single point outward.
+    // This matches standard Crow's Foot notation where the fork touches the entity.
     const perpX = -sin * 8;
     const perpY = cos * 8;
-    // Top line
+    const cx = x + cos * size;  // convergence point (outward along edge)
+    const cy = y + sin * size;
+    // Top prong
     elements.push(
-      <line key="crow1" x1={x} y1={y} x2={x + cos * size - perpX} y2={y + sin * size - perpY}
+      <line key="crow1" x1={x - perpX} y1={y - perpY} x2={cx} y2={cy}
         stroke="#374151" strokeWidth={1.5} />
     );
-    // Middle line
+    // Middle prong
     elements.push(
-      <line key="crow2" x1={x} y1={y} x2={x + cos * size} y2={y + sin * size}
+      <line key="crow2" x1={x} y1={y} x2={cx} y2={cy}
         stroke="#374151" strokeWidth={1.5} />
     );
-    // Bottom line
+    // Bottom prong
     elements.push(
-      <line key="crow3" x1={x} y1={y} x2={x + cos * size + perpX} y2={y + sin * size + perpY}
+      <line key="crow3" x1={x + perpX} y1={y + perpY} x2={cx} y2={cy}
         stroke="#374151" strokeWidth={1.5} />
     );
   } else {
-    // Single line for "one"
+    // Single line for "one", offset slightly from entity handle
+    const oneOffset = 4;
+    const ox = x + cos * oneOffset;
+    const oy = y + sin * oneOffset;
     const perpX = -sin * 8;
     const perpY = cos * 8;
     elements.push(
-      <line key="one" x1={x - perpX} y1={y - perpY} x2={x + perpX} y2={y + perpY}
+      <line key="one" x1={ox - perpX} y1={oy - perpY} x2={ox + perpX} y2={oy + perpY}
         stroke="#374151" strokeWidth={1.5} />
     );
   }
@@ -96,36 +108,53 @@ export function drawMarker(
   return elements;
 }
 
+/**
+ * Convert a handle Position to the outward-pointing angle for marker drawing.
+ * The angle points away from the entity along the edge, so `drawMarker`'s fan
+ * (which spreads in the angle direction) opens toward the entity — matching
+ * standard Crow's Foot notation where the prongs face the entity.
+ */
+export function positionToAngle(position: Position): number {
+  switch (position) {
+    case Position.Right:  return 0;             // edge exits right → angle rightward (outward)
+    case Position.Left:   return Math.PI;       // edge exits left  → angle leftward (outward)
+    case Position.Bottom: return Math.PI / 2;   // edge exits down  → angle downward (outward)
+    case Position.Top:    return -Math.PI / 2;  // edge exits up    → angle upward (outward)
+  }
+}
+
 export function CrowsFootEdge({
   id,
   sourceX,
   sourceY,
+  sourcePosition,
   targetX,
   targetY,
+  targetPosition,
   data,
 }: EdgeProps<CrowsFootEdgeType>) {
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
     sourceY,
+    sourcePosition,
     targetX,
     targetY,
+    targetPosition,
     borderRadius: 8,
   });
 
-  const sourceAngle = Math.atan2(targetY - sourceY, targetX - sourceX);
-  const targetAngle = Math.atan2(sourceY - targetY, sourceX - targetX);
+  const sourceAngle = positionToAngle(sourcePosition);
+  const targetAngle = positionToAngle(targetPosition);
 
   return (
     <>
       <BaseEdge id={id} path={edgePath} style={{ stroke: '#374151', strokeWidth: 1.5 }} />
 
       {/* Markers at source and target */}
-      <svg className="react-flow__edge-interaction" style={{ overflow: 'visible' }}>
-        <g>
-          {data?.sourceCardinality && drawMarker(data.sourceCardinality, sourceX, sourceY, sourceAngle)}
-          {data?.targetCardinality && drawMarker(data.targetCardinality, targetX, targetY, targetAngle)}
-        </g>
-      </svg>
+      <g>
+        {data?.sourceCardinality && drawMarker(data.sourceCardinality, sourceX, sourceY, sourceAngle)}
+        {data?.targetCardinality && drawMarker(data.targetCardinality, targetX, targetY, targetAngle)}
+      </g>
 
       {/* Relationship name label */}
       {data?.relationship && (

--- a/src/renderer/shared/getHandlesForPair.ts
+++ b/src/renderer/shared/getHandlesForPair.ts
@@ -1,0 +1,21 @@
+/**
+ * Determine which side handles to use for source/target based on their relative positions.
+ * Returns handle IDs matching those in NodeHandles.tsx.
+ */
+export function getHandlesForPair(
+  sourcePos: { x: number; y: number },
+  targetPos: { x: number; y: number },
+): { sourceHandle: string; targetHandle: string } {
+  const dx = targetPos.x - sourcePos.x;
+  const dy = targetPos.y - sourcePos.y;
+
+  if (Math.abs(dx) > Math.abs(dy)) {
+    return dx > 0
+      ? { sourceHandle: 'right-src', targetHandle: 'left' }
+      : { sourceHandle: 'left-src', targetHandle: 'right' };
+  } else {
+    return dy > 0
+      ? { sourceHandle: 'bottom-src', targetHandle: 'top' }
+      : { sourceHandle: 'top-src', targetHandle: 'bottom' };
+  }
+}


### PR DESCRIPTION
## Summary
- **Fix marker overlap**: Extract `getHandlesForPair` shared utility and assign `sourceHandle`/`targetHandle` on Crow's Foot edges so multiple relationships from the same entity connect to different sides instead of overlapping at one point
- **Fix marker orientation**: Compute marker angles from handle positions (axis-aligned 0°/90°/180°/270°) instead of `atan2` between endpoints, and pass `sourcePosition`/`targetPosition` to `getSmoothStepPath` for correct orthogonal path routing
- **Fix marker rendering**: Replace nested `<svg>` with `<g>` so markers render in React Flow's SVG coordinate space; reverse crow's foot prong direction so the fork touches the entity per standard Crow's Foot (IE) notation; tune marker spacing for clean visuals

Closes #9

## Test plan
- [x] All 618 tests pass (`npm test`)
- [x] Coverage thresholds met (96% stmt, 90% branch, 98% fn, 97% line)
- [ ] Manual: create entities with multiple relationships in Crow's Foot mode — edges connect to different sides, no overlap
- [ ] Manual: verify crow's foot prongs point toward entity, bar/circle symbols are farther from entity
- [ ] Manual: verify "one and only one" (`||`) bars are close together with visible gap from entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)