### PR TITLE
Fix candidate keys missing NOT NULL in DDL

### DIFF
--- a/src/exporter/BaseExporter.ts
+++ b/src/exporter/BaseExporter.ts
@@ -247,6 +247,11 @@ export abstract class BaseExporter implements Exporter {
         .filter((n): n is string => n != null);
       if (attrs.length > 0) {
         uniqueConstraints.push(attrs);
+        // Candidate keys must be NOT NULL
+        for (const attrName of attrs) {
+          const col = columns.find((c) => c.name === attrName);
+          if (col) col.nullable = false;
+        }
       }
     }
 

--- a/src/exporter/__tests__/MySQLExporter.test.ts
+++ b/src/exporter/__tests__/MySQLExporter.test.ts
@@ -234,6 +234,34 @@ describe('MySQLExporter', () => {
     expect(result.warnings).toHaveLength(0);
   });
 
+  // -----------------------------------------------------------------------
+  // Candidate key columns must be NOT NULL (issue #16)
+  // -----------------------------------------------------------------------
+
+  it('adds NOT NULL to candidate key column even when attribute is nullable', () => {
+    function makeUK(attrIds: string[], id = 'uk1'): CandidateKey {
+      return { id, name: 'UK', attributeIds: attrIds, isPrimary: false };
+    }
+    const model: ERDModel = {
+      entities: [
+        makeEntity({
+          id: 'e1',
+          name: 'Students',
+          attributes: [
+            makeAttr({ id: 'a1', name: 'email', dataType: { name: 'VARCHAR', precision: 255 }, nullable: false }),
+            makeAttr({ id: 'a2', name: 'ids', dataType: { name: 'VARCHAR', precision: 255 }, nullable: true }),
+          ],
+          candidateKeys: [makePK(['a1']), makeUK(['a2'])],
+        }),
+      ],
+      relationships: [],
+      aggregations: [],
+    };
+    const result = exporter.export(model);
+    expect(result.ddl).toContain('`ids` VARCHAR(255) NOT NULL');
+    expect(result.ddl).toContain('UNIQUE (`ids`)');
+  });
+
   it('handles 1:N FK with backtick quoting', () => {
     const model: ERDModel = {
       entities: [

--- a/src/exporter/__tests__/PostgreSQLExporter.test.ts
+++ b/src/exporter/__tests__/PostgreSQLExporter.test.ts
@@ -1292,6 +1292,78 @@ describe('PostgreSQLExporter', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Candidate key columns must be NOT NULL (issue #16)
+  // -----------------------------------------------------------------------
+
+  it('adds NOT NULL to candidate key column even when attribute is nullable', () => {
+    const model: ERDModel = {
+      entities: [
+        makeEntity({
+          id: 'e1',
+          name: 'Students',
+          attributes: [
+            makeAttr({ id: 'a1', name: 'Names', dataType: { name: 'VARCHAR', precision: 255 }, nullable: false }),
+            makeAttr({ id: 'a2', name: 'Emails', dataType: { name: 'VARCHAR', precision: 255 }, nullable: false }),
+            makeAttr({ id: 'a3', name: 'ids', dataType: { name: 'VARCHAR', precision: 255 }, nullable: true }),
+          ],
+          candidateKeys: [makePK(['a2']), makeUK(['a3'])],
+        }),
+      ],
+      relationships: [],
+      aggregations: [],
+    };
+    const result = exporter.export(model);
+    expect(result.ddl).toContain('"ids" VARCHAR(255) NOT NULL');
+    expect(result.ddl).toContain('UNIQUE ("ids")');
+    expect(result.ddl).toContain('PRIMARY KEY ("Emails")');
+  });
+
+  it('adds NOT NULL to all columns in a composite candidate key', () => {
+    const model: ERDModel = {
+      entities: [
+        makeEntity({
+          id: 'e1',
+          name: 'T',
+          attributes: [
+            makeAttr({ id: 'a1', name: 'id', dataType: { name: 'INT' }, nullable: false }),
+            makeAttr({ id: 'a2', name: 'first_name', dataType: { name: 'VARCHAR' }, nullable: true }),
+            makeAttr({ id: 'a3', name: 'last_name', dataType: { name: 'VARCHAR' }, nullable: true }),
+          ],
+          candidateKeys: [makePK(['a1']), makeUK(['a2', 'a3'])],
+        }),
+      ],
+      relationships: [],
+      aggregations: [],
+    };
+    const result = exporter.export(model);
+    expect(result.ddl).toContain('"first_name" VARCHAR(255) NOT NULL');
+    expect(result.ddl).toContain('"last_name" VARCHAR(255) NOT NULL');
+    expect(result.ddl).toContain('UNIQUE ("first_name", "last_name")');
+  });
+
+  it('adds NOT NULL to multiple candidate key columns across separate keys', () => {
+    const model: ERDModel = {
+      entities: [
+        makeEntity({
+          id: 'e1',
+          name: 'T',
+          attributes: [
+            makeAttr({ id: 'a1', name: 'id', dataType: { name: 'INT' }, nullable: false }),
+            makeAttr({ id: 'a2', name: 'email', dataType: { name: 'VARCHAR' }, nullable: true }),
+            makeAttr({ id: 'a3', name: 'ssn', dataType: { name: 'VARCHAR' }, nullable: true }),
+          ],
+          candidateKeys: [makePK(['a1']), makeUK(['a2'], 'uk1'), makeUK(['a3'], 'uk2')],
+        }),
+      ],
+      relationships: [],
+      aggregations: [],
+    };
+    const result = exporter.export(model);
+    expect(result.ddl).toContain('"email" VARCHAR(255) NOT NULL');
+    expect(result.ddl).toContain('"ssn" VARCHAR(255) NOT NULL');
+  });
+
+  // -----------------------------------------------------------------------
   // Junction table with missing entity references
   // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Candidate key (UNIQUE) columns in generated DDL now include `NOT NULL`, as required by relational database semantics
- Root cause: `buildEntityTable` in `BaseExporter.ts` created UNIQUE constraints but did not enforce NOT NULL on the corresponding columns

Closes #16

## Test plan
- [ ] Create entity with a primary key and a separate candidate key attribute
- [ ] Export to DDL and verify the candidate key column has `NOT NULL`
- [ ] 4 new unit tests added covering single, composite, and multiple candidate keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)